### PR TITLE
Java utils improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.9.0"
 
 [dependencies]
 base64 = "~0.9.0"
-jni = "~0.10.1"
+jni = { version = "~0.10.2", optional = true }
 log = "~0.4.1"
 regex = "~0.2.5"
 serde = "~1.0.27"
@@ -21,3 +21,7 @@ walkdir = "~2.0.1"
 
 [dev-dependencies]
 rand = "~0.4.2"
+
+[features]
+# Includes utilities for dealing with the JNI runtime.
+java = ["jni"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@
 )]
 
 extern crate base64;
+#[cfg(feature = "java")]
 extern crate jni;
 #[macro_use]
 extern crate log;
@@ -91,6 +92,7 @@ mod vec;
 
 pub mod bindgen_utils;
 pub mod callback;
+#[cfg(feature = "java")]
 pub mod java;
 pub mod string;
 pub mod test_utils;


### PR DESCRIPTION
* Make the Java module feature-gated (the crate will need to be included as `ffi_utils = { version = "*", features = ["java"] }`). This should optimise build times for dependent crates which don't require Java/JNI support (as it makes the `jni` lib dependency optional, too).
* Add a new enum `EnvGuard` that simplifies JNI env management (acquiring, holding the reference, and deallocating it automatically).
* Make JNI code safer and cleaner by returning `Result`s instead of using unwraps in production code.