### PR TITLE
fix/java: fix Java local refs leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,12 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-    - RUST_STABLE=1.28.0
-    - RUST_NIGHTLY=nightly-2018-07-07
-    - RUST_RUSTFMT=0.99.2
-    - RUST_CLIPPY=0.0.212
 os:
   - linux
   - osx
 language: rust
 rust:
-  - 1.28.0
-  - nightly-2018-07-07
-matrix:
-  allow_failures:
-    - rust: nightly-2018-07-07
+  - 1.29.2
 sudo: false
 branches:
   only:
@@ -25,23 +17,13 @@ cache:
 before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
-  - if [ "$TRAVIS_RUST_VERSION" = "$RUST_NIGHTLY" ] && [ "$TRAVIS_OS_NAME" = linux ]; then
-      bash cargo_install.sh rustfmt-nightly "$RUST_RUSTFMT";
-      bash cargo_install.sh clippy "$RUST_CLIPPY";
-    fi
+  - rustup component add rustfmt-preview
+  - rustup component add clippy-preview
 script:
-  - if [ "${TRAVIS_RUST_VERSION}" = "$RUST_STABLE" ]; then
-      (
-        set -x;
-        cargo test --release --verbose
-      );
-    elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-      (
-        set -x;
-        cargo fmt -- --check &&
-        cargo check &&
-        cargo clippy && cargo clippy --profile=test
-      );
-    fi
+  - set -x;
+    cargo fmt -- --check &&
+    cargo check --release &&
+    cargo clippy --release && cargo clippy --release --profile=test &&
+    cargo test --release --verbose
 before_cache:
   - cargo prune

--- a/src/java.rs
+++ b/src/java.rs
@@ -173,6 +173,7 @@ pub unsafe fn object_array_to_java<'a, T, U: Into<JObject<'a>> + 'a>(
     for (idx, entry) in list.iter().enumerate() {
         let jentry = transform_fn(entry, env)?.into();
         env.set_object_array_element(output, idx as i32, jentry)?;
+        env.delete_local_ref(jentry)?;
     }
 
     Ok(JObject::from(output))


### PR DESCRIPTION
When we convert Java objects in a loop, a new ref created with each iteration. We don't really need these refs because they are stored as array elements, so now we delete them preemptively to fix the reference leakage which is important for older Android JVMs which have a fixed limit of 512 local references.