### PR TITLE
Upgrade to rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - osx
 language: rust
 rust:
-  - 1.29.2
+  - stable
 sudo: false
 branches:
   only:
@@ -17,13 +17,13 @@ cache:
 before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
-  - rustup component add rustfmt-preview
-  - rustup component add clippy-preview
+  - rustup component add rustfmt clippy
 script:
   - set -x;
     cargo fmt -- --check &&
     cargo check --release &&
-    cargo clippy --release && cargo clippy --release --profile=test &&
+    cargo clippy --release &&
+    cargo clippy --release --profile=test &&
     cargo test --release --verbose
 before_cache:
   - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "ffi_utils"
 readme = "README.md"
 repository = "https://github.com/maidsafe/ffi_utils"
 version = "0.11.0"
+edition = "2018"
 
 [dependencies]
 base64 = "~0.9.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     RUST_BACKTRACE: 1
   matrix:
-    - RUST_TOOLCHAIN: 1.28.0
+    - RUST_TOOLCHAIN: stable
 
 cache:
   - '%USERPROFILE%\.cargo'

--- a/src/bindgen_utils.rs
+++ b/src/bindgen_utils.rs
@@ -27,11 +27,12 @@ pub fn copy_files<S: AsRef<Path>, T: AsRef<Path>>(
     for entry in WalkDir::new(source) {
         let entry = entry?;
 
-        if entry.path().is_file() && entry
-            .path()
-            .to_str()
-            .map(|s| s.ends_with(extension))
-            .unwrap_or(false)
+        if entry.path().is_file()
+            && entry
+                .path()
+                .to_str()
+                .map(|s| s.ends_with(extension))
+                .unwrap_or(false)
         {
             let source_path = entry.path();
             let target_path = target.join(source_path.strip_prefix(source).unwrap_or(source_path));

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -75,9 +75,7 @@ pub trait CallbackArgs {
 }
 
 impl CallbackArgs for () {
-    fn default() -> Self {
-        ()
-    }
+    fn default() -> Self {}
 }
 
 impl CallbackArgs for bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
     html_favicon_url = "http://maidsafe.net/img/favicon.ico",
-    test(attr(forbid(warnings))),
+    test(attr(forbid(warnings)))
 )]
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
@@ -31,8 +31,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,
@@ -42,7 +40,11 @@
     unused_comparisons,
     unused_features,
     unused_parens,
-    while_true
+    while_true,
+    clippy::all,
+    clippy::unicode_not_nfc,
+    clippy::wrong_pub_self_convention,
+    clippy::option_unwrap_used
 )]
 #![warn(
     trivial_casts,
@@ -56,20 +58,10 @@
     box_pointers,
     missing_copy_implementations,
     missing_debug_implementations,
-    variant_size_differences
-)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    deny(
-        clippy,
-        unicode_not_nfc,
-        wrong_pub_self_convention,
-        option_unwrap_used
-    )
-)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(implicit_hasher, too_many_arguments, use_debug)
+    variant_size_differences,
+    clippy::implicit_hasher,
+    clippy::too_many_arguments,
+    clippy::use_debug
 )]
 
 extern crate base64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
     clippy::use_debug
 )]
 
-extern crate base64;
+use base64;
 #[cfg(feature = "java")]
 extern crate jni;
 #[macro_use]
@@ -73,7 +73,6 @@ extern crate log;
 extern crate serde_derive;
 #[macro_use]
 extern crate unwrap;
-extern crate walkdir;
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -43,8 +43,7 @@ macro_rules! ffi_result_code {
 #[macro_export]
 macro_rules! ffi_error_code {
     ($err:expr) => {{
-        #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-        #[allow(unused)]
+        #[allow(unused, clippy::useless_attribute)]
         use $crate::ErrorCode;
 
         let err = &$err;

--- a/src/string.rs
+++ b/src/string.rs
@@ -9,7 +9,7 @@
 
 //! Utilities for passing strings across FFI boundaries.
 
-use repr_c::ReprC;
+use crate::repr_c::ReprC;
 use std::error::Error;
 use std::ffi::{CStr, IntoStringError, NulError};
 use std::os::raw::c_char;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -10,7 +10,7 @@
 //! Test utilities.
 
 use super::FfiResult;
-use repr_c::ReprC;
+use crate::repr_c::ReprC;
 use std::fmt::Debug;
 use std::os::raw::c_void;
 use std::ptr;


### PR DESCRIPTION
* Upgrade compiler
* Switch to 2018 edition
* Fix compilation, fmt and clippy warnings
