### PR TITLE
chore/ci: fix errors from cargo build --release

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@
     clippy::use_debug
 )]
 
-use base64;
 #[cfg(feature = "java")]
 extern crate jni;
 #[macro_use]


### PR DESCRIPTION
Should fix CI failure