### PR TITLE
Refactor and add integration tests

### DIFF
--- a/src/bindgen_utils.rs
+++ b/src/bindgen_utils.rs
@@ -14,7 +14,7 @@ use std::io;
 use std::path::Path;
 use walkdir::WalkDir;
 
-/// Recursively copy all files with the given extension from the source to the targt directories.
+/// Recursively copy all files with the given extension from the source to the target directories.
 pub fn copy_files<S: AsRef<Path>, T: AsRef<Path>>(
     source: S,
     target: T,

--- a/src/bindgen_utils.rs
+++ b/src/bindgen_utils.rs
@@ -14,8 +14,7 @@ use std::io;
 use std::path::Path;
 use walkdir::WalkDir;
 
-/// Recursively copy all files with the given extension from the source to the
-/// targt directories.
+/// Recursively copy all files with the given extension from the source to the targt directories.
 pub fn copy_files<S: AsRef<Path>, T: AsRef<Path>>(
     source: S,
     target: T,

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -13,21 +13,6 @@ use crate::result::FfiResult;
 use std::os::raw::c_void;
 use std::ptr;
 
-/// Given a result, calls the callback if it is an error, otherwise produces the wrapped value.
-/// Should be called within `catch_unwind`, so returns `None` on error.
-#[macro_export]
-macro_rules! try_cb {
-    ($result:expr, $user_data:expr, $cb:expr) => {
-        match $result {
-            Ok(value) => value,
-            e @ Err(_) => {
-                result::call_result_cb(e, $user_data, $cb);
-                return None;
-            }
-        }
-    };
-}
-
 /// This trait allows us to treat callbacks with different number and type of arguments uniformly.
 pub trait Callback {
     /// Arguments for the callback. Should be a tuple.

--- a/src/catch_unwind.rs
+++ b/src/catch_unwind.rs
@@ -9,7 +9,6 @@
 
 use super::callback::{Callback, CallbackArgs};
 use super::{ErrorCode, FfiResult, NativeResult};
-use crate::result;
 use std::fmt::{Debug, Display};
 use std::os::raw::c_void;
 use std::panic::{self, AssertUnwindSafe};
@@ -35,7 +34,7 @@ where
     E: Debug + Display + ErrorCode + From<&'a str>,
 {
     if let Err(err) = catch_unwind_result(f) {
-        let (error_code, description) = result::ffi_result(Err::<(), E>(err));
+        let (error_code, description) = ffi_result!(Err::<(), E>(err));
         let res = NativeResult {
             error_code,
             description: Some(description),

--- a/src/catch_unwind.rs
+++ b/src/catch_unwind.rs
@@ -48,7 +48,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fmt;
+    use crate::test_utils::TestError;
     use crate::FfiResult;
 
     #[test]
@@ -103,28 +103,6 @@ mod tests {
             if let Some(f) = self.0.take() {
                 f()
             }
-        }
-    }
-
-    // Dummy error type for testing.
-    #[derive(Debug)]
-    struct TestError;
-
-    impl<'a> From<&'a str> for TestError {
-        fn from(_: &'a str) -> Self {
-            TestError
-        }
-    }
-
-    impl ErrorCode for TestError {
-        fn error_code(&self) -> i32 {
-            -1
-        }
-    }
-
-    impl Display for TestError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "Test Error")
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! FFI utilities
+//! FFI utilities.
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@ mod repr_c;
 mod vec;
 
 pub mod bindgen_utils;
-#[macro_use]
 pub mod callback;
 #[cfg(feature = "java")]
 pub mod java;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,18 +72,22 @@ mod repr_c;
 mod vec;
 
 pub mod bindgen_utils;
+#[macro_use]
 pub mod callback;
 #[cfg(feature = "java")]
 pub mod java;
+pub mod result;
 pub mod string;
 pub mod test_utils;
 
 pub use self::b64::{base64_decode, base64_encode};
 pub use self::catch_unwind::{catch_unwind_cb, catch_unwind_result};
 pub use self::repr_c::ReprC;
+pub use self::result::{FfiResult, NativeResult, FFI_RESULT_OK};
 pub use self::string::{from_c_str, StringError};
 pub use self::vec::{vec_clone_from_raw_parts, vec_into_raw_parts, SafePtr};
-use std::os::raw::{c_char, c_void};
+
+use std::os::raw::c_void;
 
 /// Type that holds opaque user data handed into FFI functions.
 #[derive(Clone, Copy)]
@@ -101,19 +105,3 @@ pub trait ErrorCode {
     /// Return the error code corresponding to this instance.
     fn error_code(&self) -> i32;
 }
-
-/// FFI result wrapper.
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct FfiResult {
-    /// Unique error code.
-    pub error_code: i32,
-    /// Error description.
-    pub description: *const c_char,
-}
-
-/// Constant value to be used for OK result.
-pub const FFI_RESULT_OK: &FfiResult = &FfiResult {
-    error_code: 0,
-    description: 0 as *const c_char,
-};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -70,6 +70,7 @@ macro_rules! call_result_cb {
         #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
         #[allow(unused)]
         use $crate::callback::{Callback, CallbackArgs};
+        use $crate::result::{FfiResult, NativeResult};
 
         let (error_code, description) = ffi_result!($result);
         let res = NativeResult {

--- a/src/repr_c.rs
+++ b/src/repr_c.rs
@@ -7,27 +7,36 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! FFI tools
+//! FFI tools.
 
-/// Trait to convert between FFI and Rust representations of types
+/// Trait to convert between FFI and Rust representations of types.
 pub trait ReprC {
-    /// C representation of the type
+    /// C representation of the type.
     type C;
-    /// Error type
+    /// Error type.
     type Error;
 
-    /// Converts from a raw type into an owned type by cloning data
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error>
+    /// Convert from a raw FFI type into a native Rust type by cloning the data.
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error>
     where
         Self: Sized;
 }
 
-impl ReprC for u64 {
-    type C = u64;
+impl ReprC for i32 {
+    type C = i32;
     type Error = ();
 
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
-        Ok(c_repr)
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(repr_c)
+    }
+}
+
+impl ReprC for i64 {
+    type C = i64;
+    type Error = ();
+
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(repr_c)
     }
 }
 
@@ -35,8 +44,17 @@ impl ReprC for u32 {
     type C = u32;
     type Error = ();
 
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
-        Ok(c_repr)
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(repr_c)
+    }
+}
+
+impl ReprC for u64 {
+    type C = u64;
+    type Error = ();
+
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(repr_c)
     }
 }
 
@@ -44,8 +62,8 @@ impl ReprC for usize {
     type C = usize;
     type Error = ();
 
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
-        Ok(c_repr)
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(repr_c)
     }
 }
 
@@ -53,8 +71,8 @@ impl<T> ReprC for *const T {
     type C = *const T;
     type Error = ();
 
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
-        Ok(c_repr)
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(repr_c)
     }
 }
 
@@ -62,8 +80,8 @@ impl<T> ReprC for *mut T {
     type C = *mut T;
     type Error = ();
 
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
-        Ok(c_repr)
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(repr_c)
     }
 }
 
@@ -71,8 +89,8 @@ impl ReprC for [u8; 24] {
     type C = *const [u8; 24];
     type Error = ();
 
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
-        Ok(*c_repr)
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(*repr_c)
     }
 }
 
@@ -80,8 +98,8 @@ impl ReprC for [u8; 32] {
     type C = *const [u8; 32];
     type Error = ();
 
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
-        Ok(*c_repr)
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(*repr_c)
     }
 }
 
@@ -89,7 +107,7 @@ impl ReprC for [u8; 64] {
     type C = *const [u8; 64];
     type Error = ();
 
-    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
-        Ok(*c_repr)
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(*repr_c)
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,149 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Utilities for handling results and errors across the FFI boundary.
+
+use crate::callback::{Callback, CallbackArgs};
+use crate::string::{self, StringError};
+use crate::{ErrorCode, ReprC};
+use log::debug;
+use std::ffi::CString;
+use std::fmt::{Debug, Display};
+use std::os::raw::{c_char, c_void};
+use std::ptr;
+
+/// Constant value to be used for OK result.
+pub const FFI_RESULT_OK: &FfiResult = &FfiResult {
+    error_code: 0,
+    description: ptr::null(),
+};
+
+/// A native Rust version of the `FfiResult` struct.
+#[derive(Clone, Debug)]
+pub struct NativeResult {
+    /// Unique error code.
+    pub error_code: i32,
+    /// Error description.
+    pub description: Option<String>,
+}
+
+impl NativeResult {
+    /// Construct FFI wrapper for the native Rust object, consuming self.
+    pub fn into_repr_c(self) -> Result<FfiResult, StringError> {
+        Ok(FfiResult {
+            error_code: self.error_code,
+            description: match self.description {
+                Some(description) => CString::new(description)
+                    .map_err(StringError::from)?
+                    .into_raw(),
+                None => ptr::null(),
+            },
+        })
+    }
+}
+
+impl ReprC for NativeResult {
+    type C = *const FfiResult;
+    type Error = StringError;
+
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        let FfiResult {
+            error_code,
+            description,
+        } = *repr_c;
+
+        Ok(Self {
+            error_code,
+            description: if description.is_null() {
+                None
+            } else {
+                Some(string::from_c_str(description).map_err(StringError::from)?)
+            },
+        })
+    }
+}
+
+/// FFI result wrapper.
+#[repr(C)]
+#[derive(Debug)]
+pub struct FfiResult {
+    /// Unique error code.
+    pub error_code: i32,
+    /// Error description.
+    pub description: *const c_char,
+}
+
+impl Drop for FfiResult {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.description.is_null() {
+                let _ = CString::from_raw(self.description as *mut _);
+            }
+        }
+    }
+}
+
+/// Convert a result into an `FfiResult` and call a callback.
+pub fn call_result_cb<E, T, U>(result: Result<T, E>, user_data: U, cb: impl Callback)
+where
+    U: Into<*mut c_void>,
+    E: Debug + Display + ErrorCode,
+{
+    let (error_code, description) = ffi_result(result);
+    let res = unwrap!(NativeResult {
+        error_code,
+        description: Some(description),
+    }
+    .into_repr_c());
+    cb.call(user_data.into(), &res, CallbackArgs::default());
+}
+
+/// Convert an error into a pair of `(error_code, description)` to be used in `FfiResult`.
+pub fn ffi_error<E>(err: E) -> (i32, String)
+where
+    E: Debug + Display + ErrorCode,
+{
+    let err_code = ffi_error_code(&err);
+    let err_desc = format!("{}", err);
+    (err_code, err_desc)
+}
+
+/// Convert an error into an i32 error code.
+pub fn ffi_error_code<E>(err: &E) -> i32
+where
+    E: Debug + ErrorCode,
+{
+    let err_str = format!("{:?}", err);
+    let err_code = err.error_code();
+
+    debug!("**ERRNO: {}** {}", err_code, err_str);
+    err_code
+}
+
+/// Convert a result into a pair of `(error_code, description)` to be used in `FfiResult`.
+pub fn ffi_result<E, T>(res: Result<T, E>) -> (i32, String)
+where
+    E: Debug + Display + ErrorCode,
+{
+    match res {
+        Ok(_) => (0, String::default()),
+        Err(error) => ffi_error(error),
+    }
+}
+
+/// Convert a result into an i32 error code.
+pub fn ffi_result_code<E, T>(res: Result<T, E>) -> i32
+where
+    E: Debug + ErrorCode,
+{
+    match res {
+        Ok(_) => 0,
+        Err(error) => ffi_error_code(&error),
+    }
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -104,7 +104,7 @@ where
     cb.call(user_data.into(), &res, CallbackArgs::default());
 }
 
-/// Convert an error into a pair of `(error_code, description)` to be used in `FfiResult`.
+/// Convert an error into a pair of `(error_code, description)` to be used in `NativeResult`.
 pub fn ffi_error<E>(err: E) -> (i32, String)
 where
     E: Debug + Display + ErrorCode,
@@ -126,7 +126,7 @@ where
     err_code
 }
 
-/// Convert a result into a pair of `(error_code, description)` to be used in `FfiResult`.
+/// Convert a result into a pair of `(error_code, description)` to be used in `NativeResult`.
 pub fn ffi_result<E, T>(res: Result<T, E>) -> (i32, String)
 where
     E: Debug + Display + ErrorCode,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -14,8 +14,8 @@ use crate::{ErrorCode, FfiResult};
 use std::fmt::{Debug, Display};
 use std::os::raw::c_void;
 use std::sync::mpsc::{self, Sender};
-use unwrap::unwrap;
 use std::{fmt, ptr, slice};
+use unwrap::unwrap;
 
 /// User data wrapper.
 pub struct UserData {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -9,9 +9,9 @@
 
 //! Test utilities.
 
-use super::FfiResult;
 use crate::repr_c::ReprC;
 use std::fmt::Debug;
+use crate::{ErrorCode, FfiResult};
 use std::os::raw::c_void;
 use std::ptr;
 use std::slice;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -11,16 +11,14 @@ use std::mem;
 use std::ptr;
 use std::slice;
 
-/// Provides FFI-safe pointers, as opposed to raw `as_ptr()` in
-/// `Vec` and `String` which can return values such as `0x01` that
-/// can cause segmentation faults with the automatic pointer
+/// Provides FFI-safe pointers, as opposed to raw `as_ptr()` in `Vec` and `String` which can return
+/// values such as `0x01` that can cause segmentation faults with the automatic pointer
 /// dereferencing on the front-end side (e.g. in Node.js).
 pub trait SafePtr {
     /// Resulting pointer type.
     type Ptr;
 
-    /// Returns a pointer that guarantees safe dereferencing
-    /// on the front-end side.
+    /// Returns a pointer that guarantees safe dereferencing on the front-end side.
     fn as_safe_ptr(&self) -> *const Self::Ptr;
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -71,9 +71,8 @@ extern crate unwrap;
 #[test]
 fn basic() {
     use ffi_utils::test_utils::{call_1, TestError};
-    use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx};
+    use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, FFI_RESULT_OK};
     use std::os::raw::c_void;
-    use std::ptr;
 
     // A typical FFI function. Returns `input_param * 42`.
     #[no_mangle]
@@ -91,12 +90,7 @@ fn basic() {
                 panic!();
             }
 
-            let result = FfiResult {
-                error_code: 0,
-                description: ptr::null(),
-            };
-
-            o_callback(user_data.0, &result, output);
+            o_callback(user_data.0, FFI_RESULT_OK, output);
 
             Ok(())
         })

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -65,6 +65,8 @@
 )]
 
 #[macro_use]
+extern crate ffi_utils;
+#[macro_use]
 extern crate unwrap;
 
 // Test the basic example from our "FFI calling conventions" doc.
@@ -113,7 +115,7 @@ fn basic() {
 // Test the utility functions as covered in "FFI calling conventions".
 #[test]
 fn utility_functions() {
-    use ffi_utils::result::call_result_cb;
+    use ffi_utils::call_result_cb;
     use ffi_utils::test_utils::TestError;
     use ffi_utils::{catch_unwind_cb, FfiResult, NativeResult, OpaqueCtx, FFI_RESULT_OK};
     use std::os::raw::c_void;
@@ -141,7 +143,9 @@ fn utility_functions() {
         catch_unwind_cb(user_data, o_callback, || -> Result<_, TestError> {
             match multiply_by_42(input_param) {
                 Ok(output) => o_callback(user_data.0, FFI_RESULT_OK, output),
-                Err(e) => call_result_cb(Err::<(), _>(e), user_data, o_callback),
+                Err(e) => {
+                    call_result_cb!(Err::<(), _>(e), user_data, o_callback);
+                }
             }
 
             Ok(())

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -72,7 +72,7 @@ extern crate unwrap;
 // Test the basic example from our "FFI calling conventions" doc.
 #[test]
 fn basic() {
-    use ffi_utils::test_utils::{call_1, TestError};
+    use ffi_utils::test_utils::TestError;
     use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, FFI_RESULT_OK};
     use std::os::raw::c_void;
 
@@ -98,17 +98,22 @@ fn basic() {
         })
     }
 
-    // Test success case.
-    let val: i32 = unsafe { unwrap!(call_1(|ud, cb| foreign_function(1, ud, cb))) };
-    assert_eq!(val, 42);
+    // Test the example.
+    {
+        use ffi_utils::test_utils::call_1;
 
-    // Test catching a panic.
-    let res: Result<i32, i32> =
-        unsafe { call_1(|ud, cb| foreign_function(::std::i32::MAX, ud, cb)) };
-    match res {
-        Ok(value) => panic!("Unexpected value: {:?}", value),
-        Err(-2) => (),
-        Err(e) => panic!("Unexpected error: {:?}", e),
+        // Test success case.
+        let val: i32 = unsafe { unwrap!(call_1(|ud, cb| foreign_function(1, ud, cb))) };
+        assert_eq!(val, 42);
+
+        // Test catching a panic.
+        let res: Result<i32, i32> =
+            unsafe { call_1(|ud, cb| foreign_function(::std::i32::MAX, ud, cb)) };
+        match res {
+            Ok(value) => panic!("Unexpected value: {:?}", value),
+            Err(-2) => (),
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
     }
 }
 
@@ -117,9 +122,8 @@ fn basic() {
 fn utility_functions() {
     use ffi_utils::call_result_cb;
     use ffi_utils::test_utils::TestError;
-    use ffi_utils::{catch_unwind_cb, FfiResult, NativeResult, OpaqueCtx, FFI_RESULT_OK};
+    use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, FFI_RESULT_OK};
     use std::os::raw::c_void;
-    use utils::call_1_ffi_result;
 
     // Function that returns a Result.
     fn multiply_by_42(input_param: i32) -> Result<i32, TestError> {
@@ -152,21 +156,27 @@ fn utility_functions() {
         })
     }
 
-    // Test success case.
-    let val: i32 = unsafe { unwrap!(call_1_ffi_result(|ud, cb| foreign_function2(1, ud, cb))) };
-    assert_eq!(val, 42);
+    // Test the example.
+    {
+        use ffi_utils::NativeResult;
+        use utils::call_1_ffi_result;
 
-    // Test error case.
-    let res: Result<i32, NativeResult> =
-        unsafe { call_1_ffi_result(|ud, cb| foreign_function2(::std::i32::MAX, ud, cb)) };
-    match res {
-        Ok(_) => panic!("Unexpected value"),
-        Err(native_result) => {
-            assert_eq!(native_result.error_code, -2);
-            assert_eq!(
-                native_result.description,
-                Some("Overflow detected and prevented".into())
-            );
+        // Test success case.
+        let val: i32 = unsafe { unwrap!(call_1_ffi_result(|ud, cb| foreign_function2(1, ud, cb))) };
+        assert_eq!(val, 42);
+
+        // Test error case.
+        let res: Result<i32, NativeResult> =
+            unsafe { call_1_ffi_result(|ud, cb| foreign_function2(::std::i32::MAX, ud, cb)) };
+        match res {
+            Ok(_) => panic!("Unexpected value"),
+            Err(native_result) => {
+                assert_eq!(native_result.error_code, -2);
+                assert_eq!(
+                    native_result.description,
+                    Some("Overflow detected and prevented".into())
+                );
+            }
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,216 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Integration tests for FFI utilities.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
+    html_favicon_url = "http://maidsafe.net/img/favicon.ico",
+    test(attr(forbid(warnings)))
+)]
+// For explanation of lint checks, run `rustc -W help` or see
+// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
+#![forbid(
+    exceeding_bitshifts,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types,
+    warnings
+)]
+#![deny(
+    bad_style,
+    deprecated,
+    improper_ctypes,
+    missing_docs,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    plugin_as_library,
+    stable_features,
+    unconditional_recursion,
+    unknown_lints,
+    unused,
+    unused_allocation,
+    unused_attributes,
+    unused_comparisons,
+    unused_features,
+    unused_parens,
+    while_true,
+    clippy::all,
+    clippy::unicode_not_nfc,
+    clippy::wrong_pub_self_convention,
+    clippy::option_unwrap_used
+)]
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
+)]
+#![allow(
+    box_pointers,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    variant_size_differences,
+    clippy::implicit_hasher,
+    clippy::too_many_arguments,
+    clippy::use_debug
+)]
+
+#[macro_use]
+extern crate unwrap;
+
+// Test the basic example from our "FFI calling conventions" doc.
+#[test]
+fn basic() {
+    use ffi_utils::test_utils::{call_1, TestError};
+    use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx};
+    use std::os::raw::c_void;
+    use std::ptr;
+
+    // A typical FFI function. Returns `input_param * 42`.
+    #[no_mangle]
+    unsafe extern "C" fn foreign_function(
+        input_param: i32,
+        user_data: *mut c_void,
+        o_callback: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, value: i32),
+    ) {
+        let user_data = OpaqueCtx(user_data);
+
+        catch_unwind_cb(user_data, o_callback, || -> Result<_, TestError> {
+            // Induce a panic on overflow in both debug and release builds.
+            let (output, overflow) = input_param.overflowing_mul(42);
+            if overflow {
+                panic!();
+            }
+
+            let result = FfiResult {
+                error_code: 0,
+                description: ptr::null(),
+            };
+
+            o_callback(user_data.0, &result, output);
+
+            Ok(())
+        })
+    }
+
+    // Test success case.
+    let val: i32 = unsafe { unwrap!(call_1(|ud, cb| foreign_function(1, ud, cb))) };
+    assert_eq!(val, 42);
+
+    // Test catching a panic.
+    let res: Result<i32, i32> =
+        unsafe { call_1(|ud, cb| foreign_function(::std::i32::MAX, ud, cb)) };
+    match res {
+        Ok(value) => panic!("Unexpected value: {:?}", value),
+        Err(-2) => (),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
+}
+
+// Test the utility functions as covered in "FFI calling conventions".
+#[test]
+fn utility_functions() {
+    use ffi_utils::result::call_result_cb;
+    use ffi_utils::test_utils::TestError;
+    use ffi_utils::{catch_unwind_cb, FfiResult, NativeResult, OpaqueCtx, FFI_RESULT_OK};
+    use std::os::raw::c_void;
+    use utils::call_1_ffi_result;
+
+    // Function that returns a Result.
+    fn multiply_by_42(input_param: i32) -> Result<i32, TestError> {
+        let (output, overflow) = input_param.overflowing_mul(42);
+        if overflow {
+            Err(TestError::FromStr("Overflow detected and prevented".into()))
+        } else {
+            Ok(output)
+        }
+    }
+
+    // A typical FFI function. Returns `input_param * 42`.
+    #[no_mangle]
+    unsafe extern "C" fn foreign_function2(
+        input_param: i32,
+        user_data: *mut c_void,
+        o_callback: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, value: i32),
+    ) {
+        let user_data = OpaqueCtx(user_data);
+
+        catch_unwind_cb(user_data, o_callback, || -> Result<_, TestError> {
+            match multiply_by_42(input_param) {
+                Ok(output) => o_callback(user_data.0, FFI_RESULT_OK, output),
+                Err(e) => call_result_cb(Err::<(), _>(e), user_data, o_callback),
+            }
+
+            Ok(())
+        })
+    }
+
+    // Test success case.
+    let val: i32 = unsafe { unwrap!(call_1_ffi_result(|ud, cb| foreign_function2(1, ud, cb))) };
+    assert_eq!(val, 42);
+
+    // Test error case.
+    let res: Result<i32, NativeResult> =
+        unsafe { call_1_ffi_result(|ud, cb| foreign_function2(::std::i32::MAX, ud, cb)) };
+    match res {
+        Ok(_) => panic!("Unexpected value"),
+        Err(native_result) => {
+            assert_eq!(native_result.error_code, -2);
+            assert_eq!(
+                native_result.description,
+                Some("Overflow detected and prevented".into())
+            );
+        }
+    }
+}
+
+mod utils {
+    use ffi_utils::test_utils::{send_via_user_data, sender_as_user_data, SendWrapper};
+    use ffi_utils::{FfiResult, NativeResult, ReprC};
+    use std::fmt::Debug;
+    use std::os::raw::c_void;
+    use std::sync::mpsc;
+
+    pub unsafe fn call_1_ffi_result<F, E: Debug, T>(f: F) -> Result<T, NativeResult>
+    where
+        F: FnOnce(
+            *mut c_void,
+            extern "C" fn(user_data: *mut c_void, result: *const FfiResult, T::C),
+        ),
+        T: ReprC<Error = E>,
+    {
+        let (tx, rx) = mpsc::channel::<SendWrapper<Result<T, NativeResult>>>();
+        f(
+            sender_as_user_data(&tx, &mut Default::default()),
+            callback_1_ffi_result::<E, T>,
+        );
+        unwrap!(rx.recv()).0
+    }
+
+    extern "C" fn callback_1_ffi_result<E, T>(
+        user_data: *mut c_void,
+        res: *const FfiResult,
+        arg: T::C,
+    ) where
+        E: Debug,
+        T: ReprC<Error = E>,
+    {
+        unsafe {
+            let result: Result<T, NativeResult> = if (*res).error_code == 0 {
+                Ok(unwrap!(T::clone_from_repr_c(arg)))
+            } else {
+                Err(unwrap!(NativeResult::clone_from_repr_c(res)))
+            };
+            send_via_user_data(user_data, SendWrapper(result));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #17 

+ move macros to result.rs, introduce `NativeResult` type  (see commit message for more info)
+ move TestError to test_utils 
+ implement ReprC for i32 and i64 types
+ add integration test for the crate