### PR TITLE
fix/java: fix some of the Java macros missing `use` statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ script:
   - set -x;
     cargo fmt -- --check &&
     cargo check --release &&
-    cargo clippy --release &&
-    cargo clippy --release --profile=test &&
-    cargo test --release --verbose
+    cargo clippy --release --all-targets &&
+    cargo test --release --verbose --features java
 before_cache:
   - cargo prune

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,7 +51,7 @@ macro_rules! ffi_result_code {
 #[macro_export]
 macro_rules! ffi_error_code {
     ($err:expr) => {{
-        #[allow(unused, clippy::useless_attribute)]
+        #[allow(unused_imports, clippy::useless_attribute)]
         use $crate::ErrorCode;
 
         let err = &$err;
@@ -67,8 +67,7 @@ macro_rules! ffi_error_code {
 #[macro_export]
 macro_rules! call_result_cb {
     ($result:expr, $user_data:expr, $cb:expr) => {
-        #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-        #[allow(unused)]
+        #[allow(unused_imports, clippy::useless_attribute)]
         use $crate::callback::{Callback, CallbackArgs};
         use $crate::result::{FfiResult, NativeResult};
 


### PR DESCRIPTION
+ Note that not all macros have been fixed yet as it was taking too long to
figure out how to test them
+ Also brought in the `ToJava` and `FromJava` traits, which are referenced in
the macros but defined in SCL

See https://github.com/maidsafe/ffi_utils/issues/26