### PR TITLE
chore/ci: simplify travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ before_script:
 script:
   - set -x;
     cargo fmt -- --check &&
-    cargo check --release &&
-    cargo clippy --release &&
-    cargo clippy --release --profile=test &&
-    cargo test --release --verbose
+    cargo clippy --verbose --release --all-targets &&
+    cargo test --verbose --release
 before_cache:
   - cargo prune


### PR DESCRIPTION
The `cargo check` line was not needed anymore, and the two `cargo clippy` calls
could be simplified into a single one.