### PR TITLE
chore/lints: remove explicitly-listed non-warn lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,39 +14,9 @@
     html_favicon_url = "http://maidsafe.net/img/favicon.ico",
     test(attr(forbid(warnings)))
 )]
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true,
-    clippy::all,
-    clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention,
-    clippy::option_unwrap_used
-)]
+// For explanation of lint checks, run `rustc -W help`.
 #![warn(
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
@@ -54,19 +24,8 @@
     unused_qualifications,
     unused_results
 )]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences,
-    clippy::implicit_hasher,
-    clippy::too_many_arguments,
-    clippy::use_debug,
-    // These functions specifically used for FFI are missing safety documentation.
-    // It is probably not necessary for us to provide this for every single function
-    // as that would be repetitive and verbose.
-    clippy::missing_safety_doc
-)]
+// This crate makes liberal use of unsafe code to work with FFI.
+#![allow(unsafe_code)]
 
 #[macro_use]
 mod macros;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -9,6 +9,11 @@
 
 //! Test utilities.
 
+// These functions specifically used for FFI are missing safety documentation.
+// It is probably not necessary for us to provide this for every single function
+// as that would be repetitive and verbose.
+#![allow(clippy::missing_safety_doc)]
+
 use crate::repr_c::ReprC;
 use crate::{ErrorCode, FfiResult};
 use std::fmt::{Debug, Display};

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -50,12 +50,20 @@ pub fn vec_into_raw_parts<T>(v: Vec<T>) -> (*mut T, usize) {
 }
 
 /// Retakes ownership of a `Vec` that was transferred to C via `vec_into_raw_parts`.
+///
+/// # Safety
+///
+/// Unsafe. See documentation for `slice::from_raw_parts_mut` and `Box::from_raw`.
 pub unsafe fn vec_from_raw_parts<T>(ptr: *mut T, len: usize) -> Vec<T> {
     Box::from_raw(slice::from_raw_parts_mut(ptr, len)).into_vec()
 }
 
 /// Converts a pointer and length to `Vec` by cloning the contents.
 /// Note: This does NOT free the memory pointed to by `ptr`.
+///
+/// # Safety
+///
+/// Unsafe. See documentation for `slice::from_raw_parts`.
 pub unsafe fn vec_clone_from_raw_parts<T: Clone>(ptr: *const T, len: usize) -> Vec<T> {
     slice::from_raw_parts(ptr, len).to_vec()
 }


### PR DESCRIPTION
See https://hackmd.io/8odS50_AQV6U1wCHBfbeuw for the motivation.

- Removed all `forbid` items: most are already `deny` by the compiler, not clear
what explicitly forbidding them gives us.

- `unsafe_code` was `allow`ed, due to being pervasive in this crate (due to
working with low-level FFI concepts).

- Existing `warn` items mostly unchanged, except that a couple were added. These
are all `allow` by the compiler, but useful to get warnings about.

- Removed all `allow` items: they are already `allow` by the compiler.